### PR TITLE
docs: remove reference to custom winapi fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,6 @@ Cocoa core still needed!
 
 # License
 
-systray-rs includes some code
-from [winapi-rs, by retep998](https://github.com/retep998/winapi-rs).
-This code is covered under the MIT license. This code will be removed
-once winapi-rs has a 0.3 crate available.
-
 systray-rs is BSD licensed.
 
     Copyright (c) 2016-2020, Nonpolynomial Labs, LLC


### PR DESCRIPTION
From https://github.com/qdot/systray-rs/pull/42